### PR TITLE
added gist for upgrading the heroku stack for an existing app

### DIFF
--- a/gists/upgrading-heroku-stack.md
+++ b/gists/upgrading-heroku-stack.md
@@ -1,0 +1,41 @@
+# Upgrading Heroku Stack in an Existing Project
+
+## Before You Start
+
+- Determine which version of Ruby the project is using and if it is compatible with the Heroku stack you are targeting. See
+  [Heroku Ruby Versions]([https://devcenter.heroku.com/articles/ruby-support#ruby-versions]) for more information.
+- If you need to upgrade Ruby, consider the end-of-life date for the Rubies that are compatible with the Heroku stack you are targeting. Don't choose a Ruby that has reached EOL or one that's close because EOL Rubies do not receive security updates. [Ruby Maintenance Branches]([https://www.ruby-lang.org/en/downloads/branches/]).
+
+## Process
+
+1. If you need to upgrade Ruby, cut a feature branch from dev and follow the instructions in the [Upgrading Ruby]([https://github.com/LaunchPadLab/opex-public/blob/master/gists/upgrading-ruby.md]) gist.
+2. Once Ruby is upgraded to the targeted version, Heroku recommends testing the new stack in a Review App. Inside `app.json` add a reference to the new Heroku stack.
+
+```ruby
+{
+ "name": "awesome_app",
+  "stack": "heroku-18",
+  "description": "",
+  ...
+}
+```
+
+3. Pushing this branch and creating a pull request for it into dev will deploy the app on the new stack as a Review App where it can be thoroughly tested.
+4. If all is right with the Review App on the new stack, set staging to use the new stack: `heroku stack:set heroku-18 -a awesome_app_staging`.
+5. For apps that have previously been built, this does not immediately change the stack of the app. A new build is required (which will target the chosen stack) for the change to take effect. Merge your dev branch changes into staging and deploy to staging with `git push staging staging` (assuming your remote is name "staging").
+6. If everything checks out on staging, perform steps 4 and 5 again to upgrade production to the new stack and trigger a build.
+7. To confirm the new Heroku stack is running on an app:
+
+```ruby
+heroku stack -a awesome_app
+# container
+# * heroku-18
+# heroku-20
+```
+
+8. To confirm the new Ruby is running:
+
+```ruby
+heroku run ruby -v -a awesome_app
+# ruby 2.6.7p197 (2021-04-05 revision 67941) [x86_64-linux]
+```

--- a/gists/upgrading-ruby.md
+++ b/gists/upgrading-ruby.md
@@ -34,14 +34,16 @@ bar({ k: 42 }) # => {:k=>42}
 
 4. Inside the Rails project, update the Ruby version in `.ruby-version`
 
-5. Also update the Ruby version in `Gemfile`
+5. Also update the Ruby version in `Gemfile`, and if the project uses Rubocop and Travis, update the Ruby in `rubocop.yml` and `travis.yml`, respectively.
 
-6. `bundle install` At this point, there will probably be errors due to some gems that don't support the new Ruby.
+6. You'll probably need to install bundler for the new Ruby, so check if it's installed with `bundler -v`. If you need it, run `gem install bundler:{version_number}`.
 
-7. If there are failures, look at the error message to determine which gem Bundler failed on. It's possible that a dependency of that gem is incompatible with the new Ruby and it needs to be updated. You can update a specific gem with `bundle update {gem-name}`. If this resolves your issue, run `bundle install` again. You may have to repeat this process a few times.
+7. Run `bundle install`. At this point, there will probably be errors due to some gems that don't support the new Ruby.
 
-8. Another option is to run `bundle update --conservative`, which updates the gems in your gemfile but prevents Bundler from updating the versions of any of the gems they depend on.
+8. If there are failures, look at the error message to determine which gem Bundler failed on. It's possible that a dependency of that gem is incompatible with the new Ruby and it needs to be updated. You can update a specific gem with `bundle update {gem-name}`. If this resolves your issue, run `bundle install` again. You may have to repeat this process a few times.
 
-9. When Bundler is finished, boot up your app and look for deprecation warnings. These warnings will identify potential failures that may occur the next time you upgrade Ruby. Now, run your test suite to make sure all the tests pass.
+9. Another option is to run `bundle update --conservative`, which updates the gems in your gemfile but prevents Bundler from updating the versions of any of the gems they depend on.
 
-10. If all is good, deploy the new Ruby to your testing environment and then to production.
+10. When Bundler is finished, boot up your app and look for deprecation warnings. These warnings will identify potential failures that may occur the next time you upgrade Ruby. Now, run your test suite to make sure all the tests pass.
+
+11. If all is good, deploy the new Ruby to your testing environment and then to production.


### PR DESCRIPTION
I upgraded the Heroku stack for and existing app and I thought it would be helpful to document the process. The process may require upgrading Ruby so I included a link to the Upgrading Ruby gist. I also made an edit to the Upgrading Ruby gist so it's clear that you probably have to install bundler for each Ruby on your machine. 