### PR TITLE
Add new Frontend Guidelines

### DIFF
--- a/gists/frontend-pull-request-guidelines.md
+++ b/gists/frontend-pull-request-guidelines.md
@@ -1,23 +1,6 @@
 # Frontend Pull Request Guidelines
 This document details guidelines for reviewing frontend (especially LPL React-flavored) code. Some of these suggestions may apply more broadly to software development in general, but are mentioned here specifically based on the frequency with which they have been observed in client-side code.
 
-## General
-- Strive for consistency. Review other areas of the code for patterns, copy and paste, make things easier for yourself.
-  - However, don't do it blindly. If you know of a better way, bring it up to the team. Maybe we should change the pattern holistically.
-- Continuously look ahead at tasks/features that are coming up later, and think about how that might affect the task you're working on
-- While comments within the code can be extremely helpful, try not to add them when your code is already clear / self documenting. If you can make some small changes (e.g., variable or function naming) to remove the need for a comment, do that!
-  - And if you make code changes around existing comments, make sure to update those as well to keep them accurate
-- Leave GitHub comments on your own code changes. That forces you to look over all the file changes closely. You might notice something you didn't mean to commit, and you can explain why you made certain decisions to help the reviewer
-- Apply your new learnings to all code changes. When implementing PR feedback, check all of your code changes again to see if the feedback could apply somewhere else
-- Our automatic formatting with Prettier sets tabs equal to 2 spaces. To see this spacing correctly in GitHub, make sure your tab size preference is set to 2 spaces
-  - In your GitHub profile, select "Appearance", find the "Tab size preference" setting and set this to "2"
-- [Hiding whitespace changes](https://share.zight.com/YEu6mj8G) when reviewing File Changes in GitHub helps real changes stand out more clearly
-
-## Branch Maintenance
-- Try to keep our repos clean. Once branches are merged in, make sure they're deleted (should be automatic if merged in through a GitHub PR). If you've abandoned a branch (including Closed the PR in GitHub), but it was already pushed up to origin, delete that branch from origin
-- Try to keep branches in sync without merge commits. When merging `dev` up to `staging` and `staging` up to `main`, use [fast-forward merges](https://stackoverflow.com/a/29673993) without separate commits
-- Make sure processes are set with the team around when and how to merge your changes past the `dev` branch
-
 ## HTML
 - The default [`type` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type) for a button is `submit`. If `type="button"` is not explicitly declared and that button is included within a form, it can submit the form (e.g., a reset button). It's best practice to always include the `type` attribute, which usually will be `button`
   - Example: https://codesandbox.io/s/button-type-woes-zl0wm2
@@ -125,10 +108,9 @@ This document details guidelines for reviewing frontend (especially LPL React-fl
 - Duplicating context or sowing confusion with a variable name (e.g., using a singular `participant` variable for an array of participants)
   - Refer to the [variable naming cheatsheet](https://github.com/kettanaito/naming-cheatsheet) for more examples
 - You probably don't need [reduce](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce). Most applications of reduce can be simplified and more performant when using [local mutation](https://typeofnan.dev/mutation-isnt-always-bad-in-javascript/)
-- Set optional booleans to default to `false` instead of `true`. Optional boolean props should need to be actively set, not enabled by default. If necessary, you can flop the logic (e.g., use `hide...` instead of `show...`, or `disable...` instead of `enable...`).
+- Set optional booleans to default to `false` instead of `true`. Optional boolean props should need to be actively set, not enabled by default. If necessary, you can flip the logic (e.g., use `hide...` instead of `show...`, or `disable...` instead of `enable...`)
 
 ## React
-- Start from the boilerplate code from [react.md](./snippets/react.md)
 - You should virtually **never** add an `onClick` prop to anything other than a `button` element
   - The `button` element contains several accessibility features out-of-the-box, including keyboard support. Creating custom markup isn't worth it and requires a lot of additional attributes to reach parity with user's expectations
 - You probably don't need `useEffect` (unless you're fetching data). Setting state in a `useEffect` is typically code smell for a use case for deriving the state, instead of syncing it
@@ -146,12 +128,7 @@ This document details guidelines for reviewing frontend (especially LPL React-fl
   - In general, double check your casing to confirm each is used appropriately
 - Never mutate a value held in the Redux store
   - https://redux.js.org/faq/immutable-data#why-is-immutability-required-by-redux
-- Keep your code clean. Remove empty brackets (or <React.Fragment>) if you make changes and there is now only one direct child element
-- Think about using "Provider" type components. We typically use these to make sure any child views have the data they need by wrapping those child views with the provider. The provider handles fetching data and storing it in redux. It can also make sure no child views are rendered until that data is available
-  - Here are some examples:
-    - ATBS - [FinancialPerformanceYearsProvider](https://github.com/LaunchPadLab/atbs-apollo-client/blob/92b9f77cd4433ebd4769342df2acec900748ca29/src/js/main/financial-performance/providers/FinancialPerformanceYearsProvider.js)
-    - Sea Tow - [AccountProvider](https://github.com/LaunchPadLab/sea-tow-client/blob/7e41139c7e12325de75b071d8814913d9a875338/src/js/main/account/components/AccountProvider.js)
-    - Senior Planet - [CategoriesProvider](https://github.com/LaunchPadLab/senior-planet-client/blob/da6103b1fb64162b0660f700d9b8c016e8f75f5f/src/js/components/CategoriesProvider.jsx)
+- Remove empty brackets (or <React.Fragment>) if you make changes and there is now only one direct child element
 - If you find you're reusing, or want to abstract out some complicated logic that includes hooks, create your own! Follow the convention of naming it with the "use" prefix and have it return useful state and/or functions. Then, use it in your components like you would any other hook
 - When creating a navigation link for in-app routing, if you're only changing the last segment of the path, only the last segment needs to be provided. This can be useful when trying to manage long paths or those with unique identifiers
   ```js
@@ -161,7 +138,7 @@ This document details guidelines for reviewing frontend (especially LPL React-fl
   /* Better */
   <Link to="appliances">Appliances</Link>  
   ```
-- Use computed selectors in redux slices to handle reused or complicated logic that needs to update immediately if another piece of state changes
+- Use computed selectors in redux slices using [`createSelector`](https://redux.js.org/usage/deriving-data-selectors#createselector-overview) to handle reused or complicated logic that needs to update immediately if another piece of state changes
   ```js
   /* Example - Dry Run and Estimate Only are two options that can be enabled at any time in the app */
   selectors.minimumPhotoCount = createSelector(

--- a/gists/frontend-pull-request-guidelines.md
+++ b/gists/frontend-pull-request-guidelines.md
@@ -1,6 +1,23 @@
 # Frontend Pull Request Guidelines
 This document details guidelines for reviewing frontend (especially LPL React-flavored) code. Some of these suggestions may apply more broadly to software development in general, but are mentioned here specifically based on the frequency with which they have been observed in client-side code.
 
+## General
+- Strive for consistency. Review other areas of the code for patterns, copy and paste, make things easier for yourself.
+  - However, don't do it blindly. If you know of a better way, bring it up to the team. Maybe we should change the pattern holistically.
+- Continuously look ahead at tasks/features that are coming up later, and think about how that might affect the task you're working on
+- While comments within the code can be extremely helpful, try not to add them when your code is already clear / self documenting. If you can make some small changes (e.g., variable or function naming) to remove the need for a comment, do that!
+  - And if you make code changes around existing comments, make sure to update those as well to keep them accurate
+- Leave GitHub comments on your own code changes. That forces you to look over all the file changes closely. You might notice something you didn't mean to commit, and you can explain why you made certain decisions to help the reviewer
+- Apply your new learnings to all code changes. When implementing PR feedback, check all of your code changes again to see if the feedback could apply somewhere else
+- Our automatic formatting with Prettier sets tabs equal to 2 spaces. To see this spacing correctly in GitHub, make sure your tab size preference is set to 2 spaces
+  - In your GitHub profile, select "Appearance", find the "Tab size preference" setting and set this to "2"
+- [Hiding whitespace changes](https://share.zight.com/YEu6mj8G) when reviewing File Changes in GitHub helps real changes stand out more clearly
+
+## Branch Maintenance
+- Try to keep our repos clean. Once branches are merged in, make sure they're deleted (should be automatic if merged in through a GitHub PR). If you've abandoned a branch (including Closed the PR in GitHub), but it was already pushed up to origin, delete that branch from origin
+- Try to keep branches in sync without merge commits. When merging `dev` up to `staging` and `staging` up to `main`, use [fast-forward merges](https://stackoverflow.com/a/29673993) without separate commits
+- Make sure processes are set with the team around when and how to merge your changes past the `dev` branch
+
 ## HTML
 - The default [`type` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type) for a button is `submit`. If `type="button"` is not explicitly declared and that button is included within a form, it can submit the form (e.g., a reset button). It's best practice to always include the `type` attribute, which usually will be `button`
   - Example: https://codesandbox.io/s/button-type-woes-zl0wm2
@@ -108,8 +125,10 @@ This document details guidelines for reviewing frontend (especially LPL React-fl
 - Duplicating context or sowing confusion with a variable name (e.g., using a singular `participant` variable for an array of participants)
   - Refer to the [variable naming cheatsheet](https://github.com/kettanaito/naming-cheatsheet) for more examples
 - You probably don't need [reduce](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce). Most applications of reduce can be simplified and more performant when using [local mutation](https://typeofnan.dev/mutation-isnt-always-bad-in-javascript/)
+- Set optional booleans to default to `false` instead of `true`. Optional boolean props should need to be actively set, not enabled by default. If necessary, you can flop the logic (e.g., use `hide...` instead of `show...`, or `disable...` instead of `enable...`).
 
 ## React
+- Start from the boilerplate code from [react.md](./snippets/react.md)
 - You should virtually **never** add an `onClick` prop to anything other than a `button` element
   - The `button` element contains several accessibility features out-of-the-box, including keyboard support. Creating custom markup isn't worth it and requires a lot of additional attributes to reach parity with user's expectations
 - You probably don't need `useEffect` (unless you're fetching data). Setting state in a `useEffect` is typically code smell for a use case for deriving the state, instead of syncing it
@@ -124,5 +143,35 @@ This document details guidelines for reviewing frontend (especially LPL React-fl
   - Reevaluate your decision to create a separate component or look for other ways to compose the functionality together (e.g., use [`children`](https://react.dev/learn/passing-props-to-a-component#passing-jsx-as-children), move state down, use the [render prop pattern](https://reactjs.org/docs/render-props.html))
 - If you're referencing a hardcoded string (or enumeration of strings), place them in `config.js` and reference them via the aliased `config` import location
   - By convention, constants are cased using SCREAMING_SNAKE_CASE
+  - In general, double check your casing to confirm each is used appropriately
 - Never mutate a value held in the Redux store
   - https://redux.js.org/faq/immutable-data#why-is-immutability-required-by-redux
+- Keep your code clean. Remove empty brackets (or <React.Fragment>) if you make changes and there is now only one direct child element
+- Think about using "Provider" type components. We typically use these to make sure any child views have the data they need by wrapping those child views with the provider. The provider handles fetching data and storing it in redux. It can also make sure no child views are rendered until that data is available
+  - Here are some examples:
+    - ATBS - [FinancialPerformanceYearsProvider](https://github.com/LaunchPadLab/atbs-apollo-client/blob/92b9f77cd4433ebd4769342df2acec900748ca29/src/js/main/financial-performance/providers/FinancialPerformanceYearsProvider.js)
+    - Sea Tow - [AccountProvider](https://github.com/LaunchPadLab/sea-tow-client/blob/7e41139c7e12325de75b071d8814913d9a875338/src/js/main/account/components/AccountProvider.js)
+    - Senior Planet - [CategoriesProvider](https://github.com/LaunchPadLab/senior-planet-client/blob/da6103b1fb64162b0660f700d9b8c016e8f75f5f/src/js/components/CategoriesProvider.jsx)
+- If you find you're reusing, or want to abstract out some complicated logic that includes hooks, create your own! Follow the convention of naming it with the "use" prefix and have it return useful state and/or functions. Then, use it in your components like you would any other hook
+- When creating a navigation link for in-app routing, if you're only changing the last segment of the path, only the last segment needs to be provided. This can be useful when trying to manage long paths or those with unique identifiers
+  ```js
+  /* Subpar */
+  <Link to="/store/12345/products/appliances">Appliances</Link>
+  
+  /* Better */
+  <Link to="appliances">Appliances</Link>  
+  ```
+- Use computed selectors in redux slices to handle reused or complicated logic that needs to update immediately if another piece of state changes
+  ```js
+  /* Example - Dry Run and Estimate Only are two options that can be enabled at any time in the app */
+  selectors.minimumPhotoCount = createSelector(
+    [selectors.cart, selectors.selectedServiceAppointment],
+    (cart, selectedServiceAppointment) => {
+      if (!cart || !selectedServiceAppointment) return null
+      
+      return cart.isDryRun || cart.isEstimateOnly
+        ? DRY_RUN_OR_ESTIMATE_ONLY_MINIMUM_PHOTO_COUNT
+        : selectedServiceAppointment.minimumPhotoCount
+    },
+  )
+  ```

--- a/gists/pull-request-guidelines.md
+++ b/gists/pull-request-guidelines.md
@@ -7,6 +7,11 @@ Guidelines for creating pull requests at LaunchPad Lab for three types of users:
 - **QA Reviewer**: An individual assigned to the pull request to not only test the new and/or updated functionality introduced by the pull request, but also to raise any issues found related to existing functionality while performing the aforementioned test. A full regression test is not expected for each pull request.
 
 ## Authors
+- Strive for consistency in your code. Make things easier for yourself by reviewing other areas of the code for patterns and copy/paste vs. starting from scratch
+  - However, don't do it blindly. If you know of a better way, bring it up to the team. Maybe we should change the pattern holistically
+- Continuously look ahead at tasks/features that are coming up later, and think about how that might affect the task you're working on
+- While comments within the code can be extremely helpful, try not to add them when your code is already clear / self documenting. If you can make some small changes (e.g., variable or function naming) to remove the need for a comment, do that
+  - And if you make code changes around existing comments, make sure to update those as well to keep them accurate
 - If there is an existing [pull request template](https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository), follow the steps and comments included
   - These templates will come out-of-the-box when starting a new project using LPL's internal starting applications
 - Convert a PR to a [draft pull request](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) if it is not ready for review yet (useful for [long-running](#long-running) prs)
@@ -17,8 +22,10 @@ Guidelines for creating pull requests at LaunchPad Lab for three types of users:
 - Add guidance about what the reviewer(s) should focus on
 - Document what the QA tester should be testing (or provide a link to where this information is documented e.g., Asana)
 - Review the diff and ensure that all changes are relevant and intentional and address all in-scope requirements
+  - Leave your own comments on the PR. That forces you to look over all the file changes closely. You might notice refactor opportunities, and can explain why you made certain decisions to help the reviewer
 - If the environment has review apps, open the review app to make sure that there are no critical errors **before** assigning for review
   - Otherwise, make sure to test all of the changes locally or in a developer sandbox
+- After you receive a review, apply your new learnings to all code changes. Review the diff again to see if the feedback could apply anywhere else
 - Merge the PR after approval is received from all assigned reviewers
   - This is typically **your** responsibility, not the reviewer's, but this process may fall to the reviewer depending on your team agreement and/or project timing (e.g., right before a deployment)
 
@@ -43,6 +50,9 @@ Things to look for:
 
 Things to ignore:
 - Formatting (spacing, indentation, quoting)
+
+Tip:
+- [Hiding whitespace changes](https://share.zight.com/YEu6mj8G) when reviewing the diff helps real changes stand out more clearly
 
 ### QA Reviewer
 Things to look for:
@@ -70,3 +80,14 @@ A long-running PR may contain multiple features or an epic. Some best practices 
 A granular PR may contain a single feature or even a _slice_ of a single feature. Some best practices include:
 - Make sure you are very explicit about what is out of scope
 - Avoid this approach on quick projects since a reviewer's feedback could be blocking
+
+### Diff Formatting
+For JavaScript projects, our automatic formatting with Prettier sets tabs equal to 2 spaces. You can modify how tabs are displayed in GitHub by changing your tab size preference
+  - In your GitHub profile, select "Appearance", find the "Tab size preference" setting and change this to "2" (or whatever spacing your prefer)
+
+### Branch Maintenance
+Try to keep our repos clean to make it easy to read through commit history and understand what's in active development
+- Once branches are merged in, make sure they're deleted. If you've abandoned a branch (including Closed the PR in GitHub), but it was already pushed up to origin, delete that branch from origin
+  - Follow the [Project Setup Guidelines](https://github.com/LaunchPadLab/client-template/blob/main/PROJECT_SETUP_CHECKLIST.md#options) to automatically delete head branches when they're merged through a GitHub PR
+- Make sure processes are set with the team around when and how to merge your changes past the `dev` branch
+  - One option is to keep branches in sync without merge commits. This means when merging `dev` into `staging`, for example, both branches will be on the same commit to make it clear they are the same code. To implement this strategy, when merging `dev` up to `staging` and `staging` up to `main`, use [fast-forward merges](https://stackoverflow.com/a/29673993) by merging in the terminal and not through a GitHub PR

--- a/gists/pull-request-guidelines.md
+++ b/gists/pull-request-guidelines.md
@@ -87,7 +87,7 @@ For JavaScript projects, our automatic formatting with Prettier sets tabs equal 
 
 ### Branch Maintenance
 Try to keep our repos clean to make it easy to read through commit history and understand what's in active development
-- Once branches are merged in, make sure they're deleted. If you've abandoned a branch (including Closed the PR in GitHub), but it was already pushed up to origin, delete that branch from origin
+- Once branches are merged in, make sure they're deleted. If you've abandoned a branch and no longer need to reference it (including Closed the PR in GitHub), delete that branch from origin
   - Follow the [Project Setup Guidelines](https://github.com/LaunchPadLab/client-template/blob/main/PROJECT_SETUP_CHECKLIST.md#options) to automatically delete head branches when they're merged through a GitHub PR
 - Make sure processes are set with the team around when and how to merge your changes past the `dev` branch
   - One option is to keep branches in sync without merge commits. This means when merging `dev` into `staging`, for example, both branches will be on the same commit to make it clear they are the same code. To implement this strategy, when merging `dev` up to `staging` and `staging` up to `main`, use [fast-forward merges](https://stackoverflow.com/a/29673993) by merging in the terminal and not through a GitHub PR


### PR DESCRIPTION
After working with @dianacamacho and @Ramy-Huffman-LPL on the Got Junk project, we felt there was an opportunity to document many of the common (or novel) PR feedback comments to help codify those as best practices and to help future developers at LPL. Many of those were actually already covered in this guidelines doc, so I ended up just adding to it. One follow up to this may be coming up with additional ways to get devs to read this at the start of each new project 😅.

Much of the PR feedback was also very Ionic specific, so what do you think about creating a separate guidelines doc that is just for Ionic best practices? Maybe that should actually be included in https://github.com/LaunchPadLab/ionic-client-template?